### PR TITLE
Add emenda suggestion integration

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,5 +1,6 @@
 # settings.py — completo para dev (SQLite)
 from pathlib import Path
+import os
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -136,3 +137,7 @@ MEDIA_ROOT = BASE_DIR / "media"
 #  Default primary key field type
 # ──────────────────────────────────────────────────────────────
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# AssessorAI API
+AI_API_BASE_URL = "https://assessorai.fly.dev"
+AI_API_KEY = os.getenv("AI_API_KEY", "12345")

--- a/core/templates/core/sugestao_emendas.html
+++ b/core/templates/core/sugestao_emendas.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block title %}Sugestão de Emendas{% endblock title %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-4">Sugestão de Emendas</h1>
+{% if sugestoes %}
+    <form method="post">
+        {% csrf_token %}
+        <textarea name="texto" rows="15" class="w-full p-2 border border-gray-300 rounded">{{ sugestoes|safe }}</textarea>
+        <div class="mt-4">
+            <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded">Salvar</button>
+        </div>
+    </form>
+{% else %}
+    <p class="text-gray-600">Nenhuma sugestão encontrada.</p>
+{% endif %}
+{% endblock content %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from . import views
-from .views import WelcomeView, MeuMandatoView, MeuPlanejamentoView
+from .views import WelcomeView, MeuMandatoView, MeuPlanejamentoView, sugestao_emendas
 
 app_name = "core"
 
@@ -10,6 +10,7 @@ urlpatterns = [
     path("meu-planejamento/", MeuPlanejamentoView.as_view(), name="meu_planejamento"),  # Handles both create and edit
     path("planejamento/", views.planejamento_wizard, name="planejamento"),
     path("equipe/", views.gestao_equipe, name="equipe"),
+    path("sugestao-emendas/<int:arquivo_id>/", views.sugestao_emendas, name="sugestao_emendas"),
 ]
 
 # As views podem usar @login_required e decorators de papel

--- a/core/views.py
+++ b/core/views.py
@@ -4,7 +4,10 @@ from django.views.generic import TemplateView, UpdateView, CreateView
 from django.urls import reverse_lazy
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib import messages
-from .models import Mandato, User, Planejamento, Objetivo
+from django.shortcuts import get_object_or_404
+from django.conf import settings
+import requests
+from .models import Mandato, User, Planejamento, Objetivo, ArquivoBiblioteca
 from .forms import MandatoForm, PlanejamentoForm
 
 
@@ -135,6 +138,52 @@ class MeuPlanejamentoView(LoginRequiredMixin, UpdateView):
                 messages.success(self.request, 'Planejamento criado com sucesso!')
             else:
                 messages.success(self.request, 'Planejamento atualizado com sucesso!')
-            
+
             self.object = form.save()
         return super().form_valid(form)
+
+
+def sugestao_emendas(request, arquivo_id):
+    """Gera sugestões de emendas a partir de um PDF"""
+    if not request.user.is_authenticated:
+        return redirect('account_login')
+
+    user = request.user
+    if not user.mandato:
+        messages.error(request, 'Você precisa cadastrar seu mandato para usar esta função.')
+        return redirect('core:meu_mandato')
+
+    arquivo = get_object_or_404(ArquivoBiblioteca, id=arquivo_id, mandato=user.mandato)
+
+    dados = {
+        'nome_parlamentar': user.mandato.nome_parlamentar,
+        'casa_legislativa': user.mandato.get_casa_legislativa_display(),
+        'esfera': {
+            Mandato.CasaLegislativa.CM: 'Municipal',
+            Mandato.CasaLegislativa.ALE: 'Estadual',
+            Mandato.CasaLegislativa.CF: 'Federal',
+            Mandato.CasaLegislativa.SENADO: 'Federal',
+        }.get(user.mandato.casa_legislativa, ''),
+        'municipio': user.mandato.municipio,
+        'ue': user.mandato.estado,
+        'temas_interesse': getattr(getattr(user.mandato, 'planejamento', None), 'temas_interesse', ''),
+        'perfil_parlamentar': user.mandato.get_perfil_display(),
+        'espectro_politico': user.mandato.get_posicionamento_display(),
+        'origem_legislativa': 'Legislativo',
+    }
+
+    sugestoes = None
+    try:
+        with arquivo.arquivo.open('rb') as f:
+            files = {'file': f}
+            headers = {'X-API-Key': settings.AI_API_KEY}
+            url = f"{settings.AI_API_BASE_URL}/expert/pl/sugestao_emendas"
+            resp = requests.post(url, headers=headers, files=files, data=dados, timeout=60)
+            if resp.ok:
+                sugestoes = resp.json()
+            else:
+                sugestoes = {'erro': f'Erro {resp.status_code} ao consultar API'}
+    except Exception as exc:
+        sugestoes = {'erro': str(exc)}
+
+    return render(request, 'core/sugestao_emendas.html', {'arquivo': arquivo, 'sugestoes': sugestoes})

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ crispy-tailwind
 django-role-permissions
 django-admin-interface
 django-tailwind[reload]
+requests


### PR DESCRIPTION
## Summary
- integrate external AssessorAI service
- add `sugestao_emendas` view and template
- expose new URL for PDF amendment suggestions
- store API credentials in settings
- include `requests` dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python manage.py check`
- `python manage.py makemigrations --check`


------
https://chatgpt.com/codex/tasks/task_e_6850d0a767488321a450a4ccddf9edfc