### PR TITLE
Add Expert de PL app with document suggestions

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     # Apps locais
     "core.apps.CoreConfig",  # onde estão os modelos (Mandato, etc.)
     "theme",  # onde estão os temas (cores, fontes, etc.)
+    "expert_pl.apps.ExpertPlConfig",
 ]
 
 SITE_ID = 1

--- a/expert_pl/apps.py
+++ b/expert_pl/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class ExpertPlConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'expert_pl'

--- a/expert_pl/forms.py
+++ b/expert_pl/forms.py
@@ -1,0 +1,14 @@
+from django import forms
+from core.models import ArquivoBiblioteca
+
+class ArquivoBibliotecaForm(forms.ModelForm):
+    class Meta:
+        model = ArquivoBiblioteca
+        fields = ['titulo', 'tipo', 'arquivo']
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in self.fields.values():
+            field.widget.attrs.update({
+                'class': 'block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500'
+            })

--- a/expert_pl/templates/expert_pl/sugestao_emendas.html
+++ b/expert_pl/templates/expert_pl/sugestao_emendas.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+{% load crispy_forms_tags %}
+{% block title %}Expert de PL - Sugestão de Emendas{% endblock %}
+{% block content %}
+<h1 class="text-2xl font-bold mb-6">Sugestão de Emendas</h1>
+
+<h2 class="text-xl font-semibold mb-2">Enviar Documento</h2>
+<form method="post" enctype="multipart/form-data" class="mb-6 space-y-2">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" name="upload" class="bg-purple-600 text-white px-4 py-2 rounded">Enviar</button>
+</form>
+
+<h2 class="text-xl font-semibold mb-2">Biblioteca</h2>
+{% if arquivos %}
+<table class="w-full text-sm bg-white rounded shadow">
+    <thead>
+        <tr class="text-left">
+            <th class="py-2 px-2">Título</th>
+            <th class="py-2 px-2">Tipo</th>
+            <th class="py-2 px-2"></th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for a in arquivos %}
+        <tr class="border-t">
+            <td class="py-2 px-2">{{ a.titulo }}</td>
+            <td class="py-2 px-2">{{ a.get_tipo_display }}</td>
+            <td class="py-2 px-2 text-right">
+                <form method="post" class="inline">
+                    {% csrf_token %}
+                    <input type="hidden" name="delete_id" value="{{ a.id }}">
+                    <button type="submit" class="text-red-600">🗑</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p class="text-gray-500">Nenhum arquivo enviado.</p>
+{% endif %}
+
+<h2 class="text-xl font-semibold mt-8 mb-2">Gerar Sugestões</h2>
+<form method="post" class="space-y-4">
+    {% csrf_token %}
+    <div>
+        <label for="arquivo_select" class="block text-sm font-medium">Documento</label>
+        <select id="arquivo_select" name="arquivo_id" class="border rounded px-2 py-1 w-full">
+            <option value="">-- Selecione --</option>
+            {% for a in arquivos %}
+            <option value="{{ a.id }}">{{ a.titulo }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <button type="submit" name="generate" class="bg-blue-600 text-white px-4 py-2 rounded">Gerar</button>
+</form>
+
+{% if sugestoes %}
+<textarea rows="15" class="w-full p-2 border border-gray-300 rounded mt-6">{{ sugestoes|safe }}</textarea>
+{% endif %}
+{% endblock %}

--- a/expert_pl/urls.py
+++ b/expert_pl/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+app_name = 'expert_pl'
+
+urlpatterns = [
+    path('emendas/', views.sugestao_emendas, name='sugestao_emendas'),
+]

--- a/expert_pl/views.py
+++ b/expert_pl/views.py
@@ -1,0 +1,80 @@
+from django.shortcuts import render, redirect, get_object_or_404
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.conf import settings
+import requests
+
+from core.models import ArquivoBiblioteca
+from .forms import ArquivoBibliotecaForm
+
+@login_required
+def sugestao_emendas(request):
+    user = request.user
+    if not user.mandato:
+        messages.error(request, 'Você precisa cadastrar seu mandato para usar esta função.')
+        return redirect('core:meu_mandato')
+
+    arquivos = ArquivoBiblioteca.objects.filter(mandato=user.mandato).order_by('-created_at')
+    form = ArquivoBibliotecaForm()
+    sugestoes = None
+
+    if request.method == 'POST':
+        if 'delete_id' in request.POST:
+            arquivo = get_object_or_404(ArquivoBiblioteca, id=request.POST['delete_id'], mandato=user.mandato)
+            arquivo.delete()
+            messages.success(request, 'Arquivo removido com sucesso.')
+            return redirect('expert_pl:sugestao_emendas')
+
+        if 'upload' in request.POST:
+            form = ArquivoBibliotecaForm(request.POST, request.FILES)
+            if form.is_valid():
+                arquivo = form.save(commit=False)
+                arquivo.mandato = user.mandato
+                arquivo.save()
+                messages.success(request, 'Arquivo enviado com sucesso.')
+            else:
+                messages.error(request, 'Erro ao enviar arquivo.')
+            return redirect('expert_pl:sugestao_emendas')
+
+        if 'generate' in request.POST:
+            arquivo_id = request.POST.get('arquivo_id')
+            if not arquivo_id:
+                messages.error(request, 'Selecione um arquivo para gerar as sugestões.')
+                return redirect('expert_pl:sugestao_emendas')
+            arquivo = get_object_or_404(ArquivoBiblioteca, id=arquivo_id, mandato=user.mandato)
+            dados = {
+                'nome_parlamentar': user.mandato.nome_parlamentar,
+                'casa_legislativa': user.mandato.get_casa_legislativa_display(),
+                'esfera': {
+                    user.mandato.CasaLegislativa.CM: 'Municipal',
+                    user.mandato.CasaLegislativa.ALE: 'Estadual',
+                    user.mandato.CasaLegislativa.CF: 'Federal',
+                    user.mandato.CasaLegislativa.SENADO: 'Federal',
+                }.get(user.mandato.casa_legislativa, ''),
+                'municipio': user.mandato.municipio,
+                'ue': user.mandato.estado,
+                'temas_interesse': getattr(getattr(user.mandato, 'planejamento', None), 'temas_interesse', ''),
+                'perfil_parlamentar': user.mandato.get_perfil_display(),
+                'espectro_politico': user.mandato.get_posicionamento_display(),
+                'origem_legislativa': 'Legislativo',
+            }
+            try:
+                with arquivo.arquivo.open('rb') as f:
+                    files = {'file': f}
+                    headers = {'X-API-Key': settings.AI_API_KEY}
+                    url = f"{settings.AI_API_BASE_URL}/expert/pl/sugestao_emendas"
+                    resp = requests.post(url, headers=headers, files=files, data=dados, timeout=60)
+                    if resp.ok:
+                        sugestoes = resp.json()
+                    else:
+                        sugestoes = {'erro': f'Erro {resp.status_code} ao consultar API'}
+            except Exception as exc:
+                sugestoes = {'erro': str(exc)}
+
+    arquivos = ArquivoBiblioteca.objects.filter(mandato=user.mandato).order_by('-created_at')
+    context = {
+        'arquivos': arquivos,
+        'form': form,
+        'sugestoes': sugestoes,
+    }
+    return render(request, 'expert_pl/sugestao_emendas.html', context)

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -19,6 +19,7 @@
                 <a href="{% url 'core:planejamento' %}" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-[#8200e3] hover:text-white">Planejamento Wizard</a>
                 <a href="{% url 'core:equipe' %}" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-[#8200e3] hover:text-white">Gestão de Equipe</a>
                 <a href="{% url 'core:config_ai' %}" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-[#8200e3] hover:text-white">Configurar IA</a>
+                <a href="{% url 'expert_pl:sugestao_emendas' %}" class="block py-2.5 px-4 rounded transition duration-200 hover:bg-[#8200e3] hover:text-white">Expert de PL</a>
             </nav>
         </div>
         <div>

--- a/urls.py
+++ b/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("contas/", include("allauth.urls")),  # login/cadastro
     path("", RedirectView.as_view(url="/contas/login/", permanent=False)),  # Redirect root to login
     path("", include("core.urls")),            # app principal
+    path("expert-pl/", include("expert_pl.urls")),
 ]
 
 # Custom 404 handler


### PR DESCRIPTION
## Summary
- add Expert de PL Django app
- enable sending, listing and deleting uploaded files
- call API to generate amendment suggestions
- link Expert de PL in sidebar
- register new app and include URLs

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851666494e08321beb9783fd4d46954