### PR TITLE
Implement sidebar navigation

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -98,6 +98,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",  # necessário p/ allauth
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.sidebar_menu",
             ],
         },
     },

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,23 @@
+from typing import List, Dict
+
+def sidebar_menu(request) -> Dict[str, List[Dict]]:
+    menu = [
+        {
+            "title": "Gerencie",
+            "items": [
+                {"name": "Planejamento de Mandato", "url_name": "core:meu_planejamento"},
+                {"name": "Organização da Equipe", "url_name": "core:equipe"},
+                {"name": "Gestão de Tarefas (em breve)", "disabled": True},
+            ],
+        },
+        {
+            "title": "Produza",
+            "items": [
+                {"name": "Ofícios (em breve)", "disabled": True},
+                {"name": "Emendas de Projetos", "url_name": "expert_pl:sugestao_emendas"},
+                {"name": "Legislação (em breve)", "disabled": True},
+            ],
+        },
+    ]
+    return {"sidebar_menu": menu}
+

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -1,0 +1,26 @@
+<aside id="sidebar" class="bg-[#A541FF] text-white w-64 space-y-6 py-7 px-2 transform -translate-x-full md:translate-x-0 md:relative absolute inset-y-0 left-0 hidden md:block">
+    <nav class="mt-10">
+        {% for section in sidebar_menu %}
+            <div class="mb-4">
+                <h3 class="px-4 text-sm font-semibold uppercase tracking-wide text-gray-200">{{ section.title }}</h3>
+                <ul class="mt-2 space-y-1">
+                    {% for item in section.items %}
+                        {% if item.disabled %}
+                            <li class="py-2 px-4 text-gray-400 cursor-not-allowed">{{ item.name }}</li>
+                        {% else %}
+                            <li>
+                                <a href="{% url item.url_name %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">{{ item.name }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endfor %}
+        <hr class="border-purple-300 my-4">
+        <div class="px-4 text-sm space-y-2">
+            <p>{{ request.user.username }}</p>
+            <a href="{% url 'core:meu_mandato' %}" class="block hover:underline">Configurar perfil</a>
+        </div>
+    </nav>
+</aside>
+

--- a/theme/templates/base.html
+++ b/theme/templates/base.html
@@ -18,35 +18,10 @@
                 </svg>
             </button>
             <a href="{% url 'core:welcome' %}" class="text-xl font-semibold text-[#A541FF]">AssessorAI</a>
-            <nav class="hidden md:flex space-x-4">
-                <a href="{% url 'core:meu_planejamento' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Meu Planejamento</a>
-                <a href="{% url 'core:planejamento' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Planejamento Wizard</a>
-                <a href="{% url 'core:equipe' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Gestão de Equipe</a>
-                <a href="{% url 'core:config_ai' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Configurar IA</a>
-                <a href="{% url 'expert_pl:sugestao_emendas' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Expert de PL</a>
-                <a href="{% url 'core:meu_mandato' %}" class="text-sm text-gray-700 hover:text-[#A541FF]">Meu Mandato</a>
-                <form method="post" action="{% url 'account_logout' %}" class="inline">
-                    {% csrf_token %}
-                    <button type="submit" class="text-sm text-gray-700 hover:text-[#A541FF]">Logout</button>
-                </form>
-            </nav>
         </div>
     </header>
     <div class="md:flex">
-        <aside id="sidebar" class="bg-[#A541FF] text-white w-64 space-y-6 py-7 px-2 transform -translate-x-full md:translate-x-0 md:relative absolute inset-y-0 left-0 hidden md:block">
-            <nav class="mt-10 space-y-2">
-                <a href="{% url 'core:meu_planejamento' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Meu Planejamento</a>
-                <a href="{% url 'core:planejamento' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Planejamento Wizard</a>
-                <a href="{% url 'core:equipe' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Gestão de Equipe</a>
-                <a href="{% url 'core:config_ai' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Configurar IA</a>
-                <a href="{% url 'expert_pl:sugestao_emendas' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Expert de PL</a>
-                <a href="{% url 'core:meu_mandato' %}" class="block py-2 px-4 rounded hover:bg-[#8200e3]">Meu Mandato</a>
-                <form method="post" action="{% url 'account_logout' %}" class="w-full">
-                    {% csrf_token %}
-                    <button type="submit" class="w-full text-left py-2 px-4 rounded hover:bg-[#8200e3]">Logout</button>
-                </form>
-            </nav>
-        </aside>
+        {% include 'components/sidebar.html' %}
         <main class="flex-1 p-4 md:p-8">
             {% block content %}
             <h1 class="text-3xl text-gray-700">Bem-vindo ao AssessorAI</h1>


### PR DESCRIPTION
## Summary
- move navigation into sidebar only
- load sidebar items via context processor
- show user and profile link at sidebar bottom

## Testing
- `python manage.py check`
- `python manage.py makemigrations --check`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6851751f6fcc83218ace537c97e8162f